### PR TITLE
backreferences.txt: remove statement about mixing reference types

### DIFF
--- a/backreferences.txt
+++ b/backreferences.txt
@@ -117,19 +117,16 @@ TREE_BLOCK   full (shared)         Contains byte offset of metadata tree node
 Resolving Back References
 -------------------------
 
-Given any extent address, a combination of at most three of the back reference
-types will be encountered while resolving ownership of the extent. It is not
-possible to encounter both types of DATA back references for a single extent,
-but it is possible to encounter both types of TREE_BLOCK back references while
-resolving ownership. The natural algorithm for resolving these references is a
-typical tree recursion algorithm. Since the kernel has limited stack depth,
-recursion is generally discouraged, especially when the depth of the recursion
-is unknown at the outset. Instead, the kernel uses a ulist implementation that
-emulates the recursion by appending the next stage in resolution to the list
-and looping over the list until it is exhausted. The algorithm described below
-assumes that the reader will retain information from previous steps. In the
-kernel, that isn't always an option and redundant lookup or I/O operations may
-be required.
+Given any extent address, all of these types of back references may be
+encountered while resolving ownership of the extent. The natural algorithm for
+resolving these references is a typical tree recursion algorithm. Since the
+kernel has limited stack depth, recursion is generally discouraged, especially
+when the depth of the recursion is unknown at the outset. Instead, the kernel
+uses a ulist implementation that emulates the recursion by appending the next
+stage in resolution to the list and looping over the list until it is
+exhausted. The algorithm described below assumes that the reader will retain
+information from previous steps. In the kernel, that isn't always an option and
+redundant lookup or I/O operations may be required.
 
 The following steps refer to each stage of back reference resolution. The data
 back reference steps will only be executed once per data extent. The metadata


### PR DESCRIPTION
backreferences.txt claims that "it is not possible to encounter both
types of DATA back references for a single extent", but this is
incorrect. We can easily end up with both indirect and full back
references if a shared metadata block containing a file extent item is
COW'd:

```
# mkfs.btrfs -q disk.img
# mount disk.img /mnt
# btrfs subvol create /mnt/subvol
Create subvolume '/mnt/subvol'
# git -C ~/btrfs-progs archive HEAD | tar -C
/mnt/subvol -x
# btrfs subvol snap /mnt/{subvol,snap}
Create a snapshot of '/mnt/subvol' in '/mnt/snap'
# umount /mnt
# btrfs inspect-internal dump-tree -t 256 disk.img | grep -C 2 305016832
        item 20 key (1028 EXTENT_DATA 0) itemoff 13017 itemsize 53
                generation 7 type 1 (regular)
                extent data disk byte 305016832 nr 4096
                extent data offset 0 nr 4096 ram 4096
                extent compression 0 (none)
# btrfs inspect-internal dump-tree -t 2 disk.img | grep -A 3 305016832
        item 206 key (305016832 EXTENT_ITEM 4096) itemoff 6112 itemsize 53
                refs 1 gen 7 flags DATA
                extent data backref root 256 objectid 1028 offset 0 count 1
        item 207 key (305348608 EXTENT_ITEM 262144) itemoff 6059 itemsize 53
# mount disk.img /mnt
# btrfs inspect-internal inode-resolve 1029 /mnt/subvol
/mnt/subvol/tests/mkfs-tests/018-multidevice-overflow
# rm -r /mnt/subvol/tests/mkfs-tests/018-multidevice-overflow
# umount /mnt
# btrfs inspect-internal dump-tree -t 2 disk.img | grep -A 3 305016832
        item 208 key (305016832 EXTENT_ITEM 4096) itemoff 6038 itemsize 66
                refs 2 gen 7 flags DATA
                extent data backref root 256 objectid 1028 offset 0 count 1
                shared data backref parent 31309824 count 1
```

Signed-off-by: Omar Sandoval <osandov@osandov.com>